### PR TITLE
Add Carbon Black Cloud query builder MCP server

### DIFF
--- a/cbc_builder/Dockerfile
+++ b/cbc_builder/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1.7
+FROM python:3.12-slim
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    APP_USER=app \
+    APP_UID=10001 \
+    APP_GID=10001 \
+    APP_HOME=/app \
+    CACHE_DIR=/app/.cache
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl git socat \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -g ${APP_GID} ${APP_USER} \
+ && useradd -m -u ${APP_UID} -g ${APP_GID} -s /usr/sbin/nologin ${APP_USER} \
+ && mkdir -p ${APP_HOME} ${CACHE_DIR}
+
+WORKDIR ${APP_HOME}
+
+COPY requirements.txt ./
+RUN python -m pip install --upgrade pip setuptools wheel && \
+    pip install --no-cache-dir -r requirements.txt && \
+    python - <<'PY'
+import fastmcp, pydantic
+print("Deps OK. FastMCP:", getattr(fastmcp, "__version__", "unknown"))
+PY
+
+COPY server.py schema_loader.py query_builder.py README.md cb_edr_schema.json ./
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh && \
+    chown -R ${APP_UID}:${APP_GID} ${APP_HOME}
+
+USER ${APP_UID}:${APP_GID}
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD test -w ${CACHE_DIR} || exit 1
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["python", "server.py"]

--- a/cbc_builder/README.md
+++ b/cbc_builder/README.md
@@ -1,0 +1,52 @@
+# Carbon Black Cloud EDR Query Builder MCP Server
+
+This Model Context Protocol (MCP) server helps you explore the Carbon Black Cloud
+EDR schema and build valid search queries. It follows the same design as the
+`kql_builder` service in this repository, but it is tailored to Carbon Black's
+Lucene-inspired query syntax and metadata.
+
+## Features
+
+- **Schema-aware tools** – The server loads `cb_edr_schema.json` and exposes
+  helpers to list search types, inspect available fields, review operators, and
+  retrieve best practices or example queries.
+- **Natural-language assistance** – Provide a high-level intent and the
+  `build_query` tool will extract hashes, process names, IPs, and other
+  indicators to assemble a Carbon Black query with sensible defaults.
+- **Container-first workflow** – A lightweight Dockerfile and optional
+  `docker-compose.yml` make it easy to run the MCP server in an isolated
+  environment.
+
+## Quick start
+
+```bash
+# From the repository root
+cd cbc_builder
+pip install -r requirements.txt
+python server.py
+```
+
+Or build the Docker image:
+
+```bash
+docker build -t cbc-mcp .
+docker run --rm -it cbc-mcp
+```
+
+## Available tools
+
+- `list_search_types` – Inspect supported Carbon Black search types such as
+  process, binary, and alert searches.
+- `get_fields` – Retrieve the available fields for a given search type,
+  including descriptions from the schema file.
+- `get_operator_reference` – Surface logical and wildcard operator guidance
+  from the schema metadata.
+- `get_best_practices` – Return the published query-building best practices.
+- `get_example_queries` – Fetch representative example queries by category.
+- `build_query` – Build a Carbon Black Cloud EDR query from structured
+  parameters or from a natural-language description.
+
+The `build_query` tool returns both the composed query string and metadata about
+the recognised indicators and applied defaults, making it easier to present the
+result or offer further guidance to the user.
+

--- a/cbc_builder/__init__.py
+++ b/cbc_builder/__init__.py
@@ -1,0 +1,3 @@
+"""Carbon Black Cloud EDR query builder utilities."""
+
+from .query_builder import build_cbc_query  # noqa: F401

--- a/cbc_builder/docker-compose.yml
+++ b/cbc_builder/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.9"
+services:
+  cbc-mcp:
+    platform: linux/arm64
+    build: .
+    image: cbc-mcp:latest
+    container_name: cbc-mcp
+    user: "10001:10001"
+    working_dir: /app
+    environment:
+      - CACHE_DIR=/app/.cache
+    volumes:
+      - type: volume
+        source: cbc_mcp_cache
+        target: /app/.cache
+        consistency: delegated
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "test", "-w", "/app/.cache"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+volumes:
+  cbc_mcp_cache: {}

--- a/cbc_builder/entrypoint.sh
+++ b/cbc_builder/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${CACHE_DIR:=/app/.cache}"
+mkdir -p "$CACHE_DIR"
+
+if [ ! -w "$CACHE_DIR" ]; then
+  echo "[entrypoint] Cache dir $CACHE_DIR not writable" >&2
+  exit 1
+fi
+
+exec "$@"

--- a/cbc_builder/query_builder.py
+++ b/cbc_builder/query_builder.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
+
+from .schema_loader import normalise_search_type
+
+
+DEFAULT_SEARCH_TYPE = "process_search"
+DEFAULT_BOOLEAN_OPERATOR = "AND"
+SUPPORTED_BOOLEAN_OPERATORS = {"AND", "OR"}
+MAX_LIMIT = 5000
+
+_MD5_RE = re.compile(r"\b[a-fA-F0-9]{32}\b")
+_SHA256_RE = re.compile(r"\b[a-fA-F0-9]{64}\b")
+_IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+_IPV6_RE = re.compile(r"\b(?:[0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}\b")
+_PORT_RE = re.compile(r"\bport\s*(?:=|is)?\s*(\d{1,5})\b", re.IGNORECASE)
+_QUOTED_VALUE_RE = re.compile(r'"([^"]+)"|\'([^\']+)\'')
+
+_PROCESS_NAME_RE = re.compile(
+    r"(?:process|binary)\s+name(?:\s+(?:is|=|equals|was))?\s*[\"']?([A-Za-z0-9_.-]+)[\"']?",
+    re.IGNORECASE,
+)
+_CMDLINE_RE = re.compile(
+    r"(?:cmdline|command\s+line)\s+(?:contains|includes|with)?\s*[\"']([^\"']+)[\"']",
+    re.IGNORECASE,
+)
+_PATH_RE = re.compile(
+    r"(?:path|file\s+path)\s+(?:is|=|equals)?\s*[\"']([^\"']+)[\"']",
+    re.IGNORECASE,
+)
+_USERNAME_RE = re.compile(
+    r"user(?:name)?\s+(?:is|=|equals|running\s+as)?\s*[\"']?([A-Za-z0-9_@.-]+)[\"']?",
+    re.IGNORECASE,
+)
+_DOMAIN_RE = re.compile(
+    r"domain\s+(?:is|=|equals|contains)?\s*[\"']?([A-Za-z0-9_.-]+)[\"']?",
+    re.IGNORECASE,
+)
+
+_STOPWORDS = {
+    "find",
+    "show",
+    "me",
+    "all",
+    "process",
+    "processes",
+    "with",
+    "that",
+    "where",
+    "which",
+    "the",
+    "a",
+    "an",
+    "for",
+    "running",
+    "binary",
+    "alerts",
+    "alert",
+    "search",
+}
+
+
+class QueryBuildError(ValueError):
+    """Raised when we cannot construct a valid query."""
+
+
+def _quote_if_needed(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        return cleaned
+    cleaned = cleaned.replace("\"", r"\"")
+    if any(ch.isspace() for ch in cleaned) or ":" in cleaned:
+        return f'"{cleaned}"'
+    return cleaned
+
+
+def _sanitise_term(term: str) -> str:
+    cleaned = term.strip()
+    if not cleaned:
+        return ""
+    if any(ch in cleaned for ch in [";", "|", "\\", "(", ")", "{" ,"}"]):
+        raise QueryBuildError(f"Unsafe characters detected in term '{term}'")
+    return cleaned
+
+
+def _field_if_available(candidates: Sequence[str], available_fields: Iterable[str]) -> str | None:
+    for candidate in candidates:
+        if candidate in available_fields:
+            return candidate
+    return None
+
+
+def _collect_fields(field_map: Dict[str, Dict[str, Any]]) -> List[str]:
+    return list(field_map.keys())
+
+
+def _extract_patterns(intent: str, field_map: Dict[str, Dict[str, Any]]) -> Tuple[List[str], List[Tuple[int, int]], List[Dict[str, Any]]]:
+    expressions: List[str] = []
+    spans: List[Tuple[int, int]] = []
+    metadata: List[Dict[str, Any]] = []
+    available_fields = _collect_fields(field_map)
+
+    pattern_definitions = [
+        ("md5", _MD5_RE, ["process_md5", "md5"]),
+        ("sha256", _SHA256_RE, ["process_sha256", "sha256"]),
+        ("ipv4", _IPV4_RE, ["ipaddr", "remote_ip", "sensor_ip"]),
+        ("ipv6", _IPV6_RE, ["ipv6addr", "remote_ipv6"]),
+    ]
+
+    for label, regex, candidates in pattern_definitions:
+        for match in regex.finditer(intent):
+            field = _field_if_available(candidates, available_fields)
+            if not field:
+                continue
+            value = match.group(0)
+            expressions.append(f"{field}:{_sanitise_term(value)}")
+            spans.append(match.span())
+            metadata.append({"type": label, "field": field, "value": value})
+
+    # Explicit constructs
+    explicit_patterns = [
+        ("process_name", _PROCESS_NAME_RE, ["process_name", "observed_filename", "binary", "parent_name"]),
+        ("cmdline", _CMDLINE_RE, ["cmdline"]),
+        ("path", _PATH_RE, ["path", "observed_filename"]),
+        ("username", _USERNAME_RE, ["username", "user", "logon_user"]),
+        ("domain", _DOMAIN_RE, ["domain", "hostname"]),
+    ]
+
+    for label, regex, candidates in explicit_patterns:
+        for match in regex.finditer(intent):
+            field = _field_if_available(candidates, available_fields)
+            if not field:
+                continue
+            value = match.group(1)
+            if not value:
+                continue
+            formatted = _quote_if_needed(_sanitise_term(value))
+            expressions.append(f"{field}:{formatted}")
+            spans.append(match.span())
+            metadata.append({"type": label, "field": field, "value": value})
+
+    # Ports
+    for match in _PORT_RE.finditer(intent):
+        field = _field_if_available(["ipport", "port"], available_fields)
+        if not field:
+            continue
+        value = match.group(1)
+        expressions.append(f"{field}:{value}")
+        spans.append(match.span())
+        metadata.append({"type": "port", "field": field, "value": value})
+
+    return expressions, spans, metadata
+
+
+def _residual_terms(intent: str, spans: List[Tuple[int, int]]) -> List[str]:
+    if not intent:
+        return []
+
+    chars = list(intent)
+    for start, end in spans:
+        for idx in range(start, min(end, len(chars))):
+            chars[idx] = " "
+
+    residual = re.sub(r"\s+", " ", "".join(chars)).strip()
+    if not residual:
+        return []
+
+    terms: List[str] = []
+    for token in re.split(r"[;,]", residual):
+        token = token.strip()
+        if not token:
+            continue
+        # Remove quoted substrings to avoid duplication
+        token = _QUOTED_VALUE_RE.sub(lambda m: m.group(1) or m.group(2) or "", token)
+        words = [w for w in re.split(r"[^A-Za-z0-9_.-]+", token) if w]
+        filtered = [w for w in words if w.lower() not in _STOPWORDS and len(w) > 2]
+        for word in filtered:
+            terms.append(word)
+    return terms
+
+
+def _compose_query(expressions: List[str], boolean_operator: str) -> str:
+    if not expressions:
+        raise QueryBuildError("No search terms could be derived from the provided input")
+    return f" {boolean_operator} ".join(expressions)
+
+
+def build_cbc_query(
+    schema: Dict[str, Any],
+    *,
+    search_type: str | None = None,
+    terms: Sequence[str] | None = None,
+    natural_language_intent: str | None = None,
+    boolean_operator: str = DEFAULT_BOOLEAN_OPERATOR,
+    limit: int | None = None,
+) -> Tuple[str, Dict[str, Any]]:
+    """Build a Carbon Black Cloud EDR query string and return metadata."""
+
+    search_types = schema.get("search_types", {})
+    chosen_search_type, normalisation_log = normalise_search_type(
+        search_type or DEFAULT_SEARCH_TYPE, search_types.keys()
+    )
+
+    field_map = {}
+    if hasattr(schema, "field_map_for"):
+        # Support callers who pass CBCSchemaCache.load()
+        field_map = schema.field_map_for(chosen_search_type)  # type: ignore[attr-defined]
+    else:
+        # schema may already be the payload
+        mapping_key = {
+            "process_search": "process_search_fields",
+            "binary_search": "binary_search_fields",
+            "alert_search": "alert_search_fields",
+            "threat_report_search": "threat_report_search_fields",
+        }.get(chosen_search_type)
+        if mapping_key:
+            raw_fields = schema.get(mapping_key, {})
+            if isinstance(raw_fields, dict):
+                field_map = raw_fields
+
+    expressions: List[str] = []
+    recognised: List[Dict[str, Any]] = []
+
+    if terms:
+        for term in terms:
+            cleaned = _sanitise_term(term)
+            if not cleaned:
+                continue
+            expressions.append(cleaned)
+            recognised.append({"type": "structured", "value": cleaned})
+
+    if natural_language_intent:
+        nl_expressions, spans, meta = _extract_patterns(natural_language_intent, field_map)
+        expressions.extend(nl_expressions)
+        recognised.extend(meta)
+
+        for token in _residual_terms(natural_language_intent, spans):
+            sanitised = _sanitise_term(token)
+            if not sanitised:
+                continue
+            expressions.append(sanitised)
+            recognised.append({"type": "keyword", "value": sanitised})
+
+    if not expressions:
+        raise QueryBuildError("No expressions provided. Supply terms or natural language intent.")
+
+    operator = boolean_operator.upper().strip()
+    if operator not in SUPPORTED_BOOLEAN_OPERATORS:
+        raise QueryBuildError(
+            f"Unsupported boolean operator '{boolean_operator}'. Use one of: {', '.join(SUPPORTED_BOOLEAN_OPERATORS)}"
+        )
+
+    # Clamp limit if provided
+    limit_value: int | None = None
+    if limit is not None:
+        if limit <= 0:
+            raise QueryBuildError("Limit must be positive")
+        limit_value = min(limit, MAX_LIMIT)
+
+    query = _compose_query(expressions, operator)
+
+    metadata = {
+        "search_type": chosen_search_type,
+        "normalisation": normalisation_log,
+        "boolean_operator": operator,
+        "recognised": recognised,
+    }
+
+    if limit_value is not None:
+        metadata["limit"] = limit_value
+        if limit_value != limit:
+            metadata["limit_clamped"] = MAX_LIMIT
+
+    return query, metadata

--- a/cbc_builder/requirements.txt
+++ b/cbc_builder/requirements.txt
@@ -1,0 +1,4 @@
+# Carbon Black Cloud Query Builder MCP Server - Dependencies
+
+fastmcp>=2.0.0,<3.0.0
+pydantic>=2.7.0,<3.0.0

--- a/cbc_builder/schema_loader.py
+++ b/cbc_builder/schema_loader.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+
+class CBCSchemaCache:
+    """Load and cache the Carbon Black Cloud EDR schema file."""
+
+    def __init__(self, schema_path: Path) -> None:
+        self.schema_path = Path(schema_path)
+        self._lock = threading.Lock()
+        self._cache: Dict[str, Any] | None = None
+
+    def load(self, force_refresh: bool = False) -> Dict[str, Any]:
+        with self._lock:
+            if force_refresh or self._cache is None:
+                raw = self.schema_path.read_text(encoding="utf-8")
+                data = json.loads(raw)
+                if not isinstance(data, dict):
+                    raise ValueError("Schema root must be a JSON object")
+                payload = data.get("carbonblack_edr_query_schema")
+                if not isinstance(payload, dict):
+                    raise ValueError("Missing 'carbonblack_edr_query_schema' root key")
+                self._cache = payload
+            return self._cache
+
+    # Convenience helpers -------------------------------------------------
+
+    def search_types(self) -> Dict[str, Dict[str, Any]]:
+        return dict(self.load().get("search_types", {}))
+
+    def field_map_for(self, search_type: str) -> Dict[str, Dict[str, Any]]:
+        payload = self.load()
+        mapping_key = {
+            "process_search": "process_search_fields",
+            "binary_search": "binary_search_fields",
+            "alert_search": "alert_search_fields",
+            "threat_report_search": "threat_report_search_fields",
+        }.get(search_type)
+
+        if not mapping_key:
+            return {}
+
+        fields = payload.get(mapping_key, {})
+        return dict(fields) if isinstance(fields, dict) else {}
+
+    def list_fields(self, search_type: str) -> List[Dict[str, Any]]:
+        fields = self.field_map_for(search_type)
+        output: List[Dict[str, Any]] = []
+        for name, meta in sorted(fields.items()):
+            if isinstance(meta, dict):
+                entry = {"name": name}
+                entry.update(meta)
+                output.append(entry)
+        return output
+
+    def operator_reference(self) -> Dict[str, Any]:
+        payload = self.load()
+        return payload.get("operators", {})
+
+    def best_practices(self) -> List[str] | Dict[str, Any]:
+        payload = self.load()
+        best = payload.get("best_practices")
+        return best if isinstance(best, (list, dict)) else []
+
+    def example_queries(self) -> Dict[str, Any]:
+        payload = self.load()
+        examples = payload.get("example_queries", {})
+        return examples if isinstance(examples, dict) else {}
+
+
+def normalise_search_type(name: str | None, available: Iterable[str]) -> Tuple[str, List[str]]:
+    """Return a valid search type and a record of the normalisation steps."""
+
+    available_list = [st for st in available]
+    log: List[str] = []
+
+    if not name:
+        if available_list:
+            default = available_list[0]
+            log.append(f"defaulted_to:{default}")
+            return default, log
+        raise ValueError("No search types available in schema")
+
+    cleaned = name.strip().lower().replace(" ", "_")
+    candidates = {
+        "process": "process_search",
+        "process_search": "process_search",
+        "binary": "binary_search",
+        "binary_search": "binary_search",
+        "alert": "alert_search",
+        "alert_search": "alert_search",
+        "alerts": "alert_search",
+        "threat": "threat_report_search",
+        "threat_report": "threat_report_search",
+        "threat_report_search": "threat_report_search",
+        "report": "threat_report_search",
+    }
+
+    resolved = candidates.get(cleaned, cleaned)
+    if resolved in available_list:
+        if resolved != name:
+            log.append(f"normalised_from:{name}->{resolved}")
+        return resolved, log
+
+    # Attempt fuzzy fallback by prefix
+    for candidate in available_list:
+        if candidate.startswith(resolved):
+            log.append(f"prefix_matched:{candidate}")
+            return candidate, log
+
+    raise ValueError(f"Unknown search type '{name}'. Valid options: {', '.join(available_list)}")

--- a/cbc_builder/server.py
+++ b/cbc_builder/server.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+from schema_loader import CBCSchemaCache, normalise_search_type
+from query_builder import build_cbc_query, QueryBuildError, DEFAULT_BOOLEAN_OPERATOR, MAX_LIMIT
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+SCHEMA_FILE = Path(__file__).with_name("cb_edr_schema.json")
+cache = CBCSchemaCache(SCHEMA_FILE)
+mcp = FastMCP(name="cbc-query-builder")
+
+
+class FieldsParams(BaseModel):
+    search_type: str = Field(..., description="Carbon Black search type (process, binary, alert, threat)")
+
+
+class ExampleQueryParams(BaseModel):
+    category: Optional[str] = Field(
+        default=None,
+        description="Optional example category: process_search, binary_search, alert_search, etc.",
+    )
+
+
+class BuildQueryParams(BaseModel):
+    search_type: Optional[str] = Field(default=None, description="Desired search type (defaults to process_search)")
+    terms: Optional[List[str]] = Field(default=None, description="Pre-built expressions such as field:value pairs")
+    natural_language_intent: Optional[str] = Field(
+        default=None,
+        description="High-level description of what to search for",
+    )
+    boolean_operator: str = Field(default=DEFAULT_BOOLEAN_OPERATOR, description="Boolean operator between expressions")
+    limit: Optional[int] = Field(
+        default=None,
+        ge=1,
+        le=MAX_LIMIT,
+        description="Optional record limit hint for downstream consumers",
+    )
+
+
+@mcp.tool
+def list_search_types() -> Dict[str, Any]:
+    """List Carbon Black Cloud search types with their descriptions."""
+
+    schema = cache.load()
+    search_types = schema.get("search_types", {})
+    logger.info("Listing %d search types", len(search_types))
+    return {"search_types": search_types}
+
+
+@mcp.tool
+def get_fields(params: FieldsParams) -> Dict[str, Any]:
+    """Return available fields for a given search type."""
+
+    schema = cache.load()
+    search_type, log_entries = normalise_search_type(params.search_type, schema.get("search_types", {}).keys())
+    fields = cache.list_fields(search_type)
+    logger.info("Resolved search type %s (%s) with %d fields", params.search_type, search_type, len(fields))
+    return {"search_type": search_type, "fields": fields, "normalisation": log_entries}
+
+
+@mcp.tool
+def get_operator_reference() -> Dict[str, Any]:
+    """Return the logical, wildcard, and field operator reference."""
+
+    operators = cache.operator_reference()
+    logger.info("Returning operator reference with categories: %s", list(operators.keys()))
+    return {"operators": operators}
+
+
+@mcp.tool
+def get_best_practices() -> Dict[str, Any]:
+    """Return documented query-building best practices."""
+
+    best = cache.best_practices()
+    logger.info("Returning %s best practice entries", len(best) if isinstance(best, list) else "structured")
+    return {"best_practices": best}
+
+
+@mcp.tool
+def get_example_queries(params: ExampleQueryParams) -> Dict[str, Any]:
+    """Return example queries, optionally filtered by category."""
+
+    examples = cache.example_queries()
+    if params.category:
+        key = params.category
+        if key not in examples:
+            available = ", ".join(sorted(examples.keys()))
+            logger.warning("Unknown example category %s", key)
+            return {"error": f"Unknown category '{key}'. Available: {available}"}
+        return {"category": key, "examples": examples[key]}
+    return {"examples": examples}
+
+
+@mcp.tool
+def build_query(params: BuildQueryParams) -> Dict[str, Any]:
+    """Build a Carbon Black Cloud query from structured parameters or natural language."""
+
+    schema = cache.load()
+    payload = params.model_dump()
+    try:
+        query, metadata = build_cbc_query(schema, **payload)
+        logger.info("Built CBC query for search_type=%s", metadata.get("search_type"))
+        return {"query": query, "metadata": metadata}
+    except QueryBuildError as exc:
+        logger.warning("Failed to build query: %s", exc)
+        return {"error": str(exc)}
+
+
+if __name__ == "__main__":
+    logger.info("Starting CBC query builder MCP server")
+    mcp.run()

--- a/tests/test_cbc_builder.py
+++ b/tests/test_cbc_builder.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from cbc_builder.query_builder import build_cbc_query, QueryBuildError
+
+
+def _load_schema() -> dict:
+    schema_path = Path(__file__).resolve().parents[1] / "cbc_builder" / "cb_edr_schema.json"
+    data = json.loads(schema_path.read_text(encoding="utf-8"))
+    return data["carbonblack_edr_query_schema"]
+
+
+def test_build_query_from_natural_language_md5():
+    schema = _load_schema()
+    md5 = "5a18f00ab9330ac7539675f326cf1100"
+    query, metadata = build_cbc_query(
+        schema,
+        search_type="process",
+        natural_language_intent=f"find processes with hash {md5}",
+    )
+
+    assert md5 in query
+    assert any(entry["type"] == "md5" for entry in metadata["recognised"])
+    assert metadata["search_type"] == "process_search"
+
+
+def test_limit_clamped():
+    schema = _load_schema()
+    hash_value = "f" * 64
+    query, metadata = build_cbc_query(
+        schema,
+        search_type="binary",
+        natural_language_intent=f"binary sha256 is {hash_value}",
+        limit=999999,
+    )
+
+    assert hash_value in query
+    assert metadata["limit"] <= metadata["limit_clamped"]
+
+
+def test_error_when_no_terms():
+    schema = _load_schema()
+    with pytest.raises(QueryBuildError):
+        build_cbc_query(schema, search_type="process")


### PR DESCRIPTION
## Summary
- add a Carbon Black Cloud EDR query builder MCP server with schema-driven tools and natural-language query construction
- containerize the new service with Docker and compose definitions for easy deployment
- cover the query builder with unit tests that validate natural-language parsing, limit handling, and error paths

## Testing
- pytest tests/test_cbc_builder.py

------
https://chatgpt.com/codex/tasks/task_e_68e01c2619c0832ea08db419dd08346d